### PR TITLE
close networks inside PGTestSetup::close

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,17 @@
 # Changes for lovely-db-testing
 
+## Unreleased
+
+### Fix
+
+- close networks created by testcontainers inside `PGTestSetup.stop` to prevent having too many dangling networks around
+
+### Feature
+
+- update Gradle to 8.5
+- update Kotlin to 1.9.22
+- update testcontainers to 1.19.4
+
 ## 2023-09-21 / 0.2.0
 
 ### Fix

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.gradle.api.tasks.testing.logging.TestLogEvent.*
 
 plugins {
-    kotlin("jvm") version "1.9.10"
+    kotlin("jvm") version "1.9.22"
     id("com.lovelysystems.gradle") version "1.12.0"
     `java-library`
     `maven-publish`
@@ -27,7 +27,7 @@ repositories {
 
 dependencies {
     compileOnly("org.junit.jupiter:junit-jupiter:5.10.0")
-    api("org.testcontainers:testcontainers:1.19.0")
+    api("org.testcontainers:testcontainers:1.19.4")
 
     testImplementation("org.junit.jupiter:junit-jupiter:5.10.0")
     testImplementation(kotlin("test-junit5"))

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/kotlin/PGTestSetup.kt
+++ b/src/main/kotlin/PGTestSetup.kt
@@ -10,6 +10,8 @@ class PGTestSetup(
     private val fixedPort: Int? = null,
 ) {
 
+    private lateinit var network: Network
+
     fun reset() {
         if (resetScripts.isNotEmpty()) {
             client.runFiles(*resetScripts.toTypedArray(), dbName = "postgres")
@@ -17,7 +19,7 @@ class PGTestSetup(
     }
 
     fun start() {
-        val network = if (reuseIdent != null) {
+        network = if (reuseIdent != null) {
             // use a network named after the site
             createOrUseNetwork("ldbt_$reuseIdent")
         } else {
@@ -44,6 +46,7 @@ class PGTestSetup(
         if (reuseIdent == null) {
             client.stop()
             server.stop()
+            network.close()
         }
     }
 }

--- a/src/main/kotlin/TestContainersNetwork.kt
+++ b/src/main/kotlin/TestContainersNetwork.kt
@@ -18,7 +18,7 @@ fun createOrUseNetwork(networkName: String): Network {
         nameField.setAccessible(true)
         nameField.set(network, networkName)
         val networks = DockerClientFactory.instance().client().listNetworksCmd().withNameFilter(networkName).exec()
-        if (!networks.isEmpty()) {
+        if (networks.isNotEmpty()) {
             val idField = Network.NetworkImpl::class.java.getDeclaredField("id")
             idField.setAccessible(true)
             idField.set(network, networks[0].id)


### PR DESCRIPTION
Docker allows to have only 30 networks at the same time, and since they were not cleaned up as part of the `stop` method in `PGTestSetup`, it was possible to hit this limit in large projects where we have for example more than 30 tests using a DB instance. With this change networks can be also closed as part of the teardown process of `PGTestSetup`