### PR TITLE
fix: replace bind mounts with copy for remote Docker compat

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Changes for lovely-db-testing
 
-## 2026-04-02 / 0.4.1
+## Unreleased
 
 ### Fix
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Changes for lovely-db-testing
 
+## 2026-04-02 / 0.4.1
+
+### Fix
+
+- replace `withFileSystemBind` with `withCopyToContainer` in `PGClientContainer` for
+  remote Docker daemon compatibility (e.g. CircleCI `setup_remote_docker`)
+
 ## 2025-12-09 / 0.4.0 
 
 ### Feature

--- a/src/main/kotlin/Containers.kt
+++ b/src/main/kotlin/Containers.kt
@@ -1,10 +1,10 @@
 package com.lovelysystems.db.testing
 
-import org.testcontainers.containers.BindMode
 import org.testcontainers.containers.Container
 import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy
 import org.testcontainers.utility.DockerImageName
+import org.testcontainers.utility.MountableFile
 import java.nio.file.FileSystems
 import java.nio.file.Files
 import java.nio.file.Path
@@ -34,10 +34,10 @@ class PGClientContainer(
             it.withEntrypoint("tail", "-f", "/dev/null")
         }
         if (devDir != null) {
-            withFileSystemBind(devDir.absolutePathString(), "/pgdev", BindMode.READ_ONLY)
+            withCopyToContainer(MountableFile.forHostPath(devDir), "/pgdev")
         }
         if (testDir != null) {
-            withFileSystemBind(testDir.absolutePathString(), "/tests", BindMode.READ_ONLY)
+            withCopyToContainer(MountableFile.forHostPath(testDir), "/tests")
         }
         this.apply(configureBlock)
     }


### PR DESCRIPTION
Testcontainers-based tests now work on CI environments with remote Docker daemons (CircleCI, GitHub Actions DinD).

## What

- Replace `withFileSystemBind` with `withCopyToContainer` in `PGClientContainer` — files are sent as tarballs over the Docker API instead of requiring daemon filesystem access
- No public API changes; original mounts were read-only so copy is behaviorally identical

## Risks

- None identified

## AI Attribution

- 1 of 2 commits co-authored with Claude
- Entire fix implementation

---

#lovelyreviewdesc | base: 43b94fa | head: 2bc705d